### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
     methods,
     Rcpp (>= 0.12.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
+    rstan (>= 2.26.0),
     rstantools (>= 2.2.0),
     stats,
     truncdist (>= 1.0-2)
@@ -50,8 +50,8 @@ LinkingTo:
     Rcpp (>= 0.12.0),
     RcppEigen (>= 0.3.3.3.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
-    StanHeaders (>= 2.18.0)
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0)
 VignetteBuilder: knitr
 URL: https://koenderks.github.io/jfa/, https://github.com/koenderks/jfa
 BugReports: https://github.com/koenderks/jfa/issues

--- a/inst/stan/or_fairness.stan
+++ b/inst/stan/or_fairness.stan
@@ -1,7 +1,7 @@
 #include /include/license.stan
 
 data {
-  int<lower=0> y[4];
+  array[4] int<lower=0> y;
   real<lower=1> prior_a;
   int use_likelihood;
 }

--- a/inst/stan/pp_error.stan
+++ b/inst/stan/pp_error.stan
@@ -2,8 +2,8 @@
 
 data {
   int<lower=1> S;
-  int<lower=1> n[S];
-  int<lower=0> k[S];
+  array[S] int<lower=1> n;
+  array[S] int<lower=0> k;
   real<lower=0> alpha;
   real<lower=0> beta;
   int beta_prior;

--- a/inst/stan/pp_taint.stan
+++ b/inst/stan/pp_taint.stan
@@ -3,8 +3,8 @@
 data {
   int<lower=1> S;
   int<lower=0> n;
-  int<lower=1> s[n];
-  real<lower=0, upper=1> t[n];
+  array[n] int<lower=1> s;
+  array[n] real<lower=0, upper=1> t;
   real<lower=0> alpha;
   real<lower=0> beta;
   int beta_prior;


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
